### PR TITLE
Fix route paths

### DIFF
--- a/route.js
+++ b/route.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = app => {
-  app.get('^/$', (req, res) => {
+  app.get('/', (req, res) => {
     req.app.get('getMainContent')(content => {
       const pageInfo = {
         name: 'index',
@@ -21,7 +21,7 @@ module.exports = app => {
     });
   });
 
-  app.get('^/thread/:num', (req, res) => {
+  app.get('/thread/:num', (req, res) => {
     const api = req.app.get('API');
     const articleNum = req.params.num;
     api.threadAPI(`thread/${articleNum}`, req.cookies.keygen, result => {


### PR DESCRIPTION
參考 [Express Routing](http://expressjs.com/en/guide/routing.html) 文件，將路徑匹配的 regex 改為簡單的 string pattern。

> Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings, string patterns, or regular expressions.
> Express uses [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) for matching the route paths

範例：

原本匹配的路徑 `'^/$'`，經過 path-to-regexp 後會變成 `/^\^\/\$(?:\/)?$/i`，修改為 `/`，轉換後則是 `/^\/(?:\/)?$/i`。

如果要直接使用 regex，可改寫為

```js
app.get(/^\/$/, (req, res) => {}
```


